### PR TITLE
lavender: replace "-isolated_app" with "-isolated_app_all"

### DIFF
--- a/sepolicy/vendor/app.te
+++ b/sepolicy/vendor/app.te
@@ -1,5 +1,5 @@
-get_prop({ appdomain -isolated_app }, hal_fingerprint_prop)
-get_prop({ appdomain -isolated_app }, mlipay_prop)
+get_prop({ appdomain -isolated_app_all }, hal_fingerprint_prop)
+get_prop({ appdomain -isolated_app_all }, mlipay_prop)
 
-allow { appdomain -isolated_app } adsprpcd_file:dir r_dir_perms;
-allow { appdomain -isolated_app } public_adsprpcd_file:file r_file_perms;
+allow { appdomain -isolated_app_all } adsprpcd_file:dir r_dir_perms;
+allow { appdomain -isolated_app_all } public_adsprpcd_file:file r_file_perms;


### PR DESCRIPTION
In treble_sepolicy_test, error : Found prohibited permission granted for isolated like types. Please replace your allow statements that involve "-isolated_app" with "-isolated_app_all".