### PR TITLE
lavender: doze: Migrate to CompoundButton.OnCheckedChangeListener

### DIFF
--- a/doze/src/org/lineageos/settings/doze/DozeSettingsFragment.java
+++ b/doze/src/org/lineageos/settings/doze/DozeSettingsFragment.java
@@ -25,7 +25,7 @@ import android.content.DialogInterface;
 import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.os.Handler;
-import android.widget.Switch;
+import android.widget.CompoundButton;
 
 import androidx.preference.Preference;
 import androidx.preference.PreferenceCategory;
@@ -33,10 +33,9 @@ import androidx.preference.PreferenceFragment;
 import androidx.preference.SwitchPreference;
 
 import com.android.settingslib.widget.MainSwitchPreference;
-import com.android.settingslib.widget.OnMainSwitchChangeListener;
 
-public class DozeSettingsFragment extends PreferenceFragment implements
-        Preference.OnPreferenceChangeListener, OnMainSwitchChangeListener {
+public class DozeSettingsFragment extends PreferenceFragment
+        implements CompoundButton.OnCheckedChangeListener, Preference.OnPreferenceChangeListener {
 
     private MainSwitchPreference mSwitchBar;
 
@@ -95,7 +94,7 @@ public class DozeSettingsFragment extends PreferenceFragment implements
     }
 
     @Override
-    public void onSwitchChanged(Switch switchView, boolean isChecked) {
+    public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
         Utils.enableDoze(getActivity(), isChecked);
         Utils.checkDozeService(getActivity());
 


### PR DESCRIPTION
Switch and SwitchCompat are both CompoundButton.

Using CompoundButton in Java will helps migration in the future.

Bug: 306658427 | AOSP | AOSP
Test: manual - check Settings pages
Test: m RunSettingsLibRoboTests
Change-Id: I85a70d4c504d8584030ea4a058f30d74206ab835 | AOSP

From: https://review.lineageos.org/c/LineageOS/android_device_lenovo_sm8150-common/+/387965/9