### PR TITLE
lavender: doze: Get rid of HelpDialogFragment class

### DIFF
--- a/doze/src/org/lineageos/settings/doze/DozeSettingsFragment.java
+++ b/doze/src/org/lineageos/settings/doze/DozeSettingsFragment.java
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2015 The CyanogenMod Project
- *               2017-2018 The LineageOS Project
+ *               2017-2023 The LineageOS Project
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -108,26 +108,20 @@ public class DozeSettingsFragment extends PreferenceFragment implements
     }
 
     private void showHelp() {
-        HelpDialogFragment fragment = new HelpDialogFragment();
-        fragment.show(getFragmentManager(), "help_dialog");
-    }
-
-    private static class HelpDialogFragment extends DialogFragment {
-        @Override
-        public Dialog onCreateDialog(Bundle savedInstanceState) {
-            return new AlertDialog.Builder(getActivity())
-                    .setTitle(R.string.doze_settings_help_title)
-                    .setMessage(R.string.doze_settings_help_text)
-                    .setNegativeButton(R.string.dialog_ok, (dialog, which) -> dialog.cancel())
-                    .create();
-        }
-
-        @Override
-        public void onCancel(DialogInterface dialog) {
-            getActivity().getSharedPreferences("doze_settings", Activity.MODE_PRIVATE)
-                    .edit()
-                    .putBoolean("first_help_shown", true)
-                    .commit();
+        AlertDialog helpDialog = new AlertDialog.Builder(getActivity())
+                .setTitle(R.string.doze_settings_help_title)
+                .setMessage(R.string.doze_settings_help_text)
+                .setPositiveButton(R.string.dialog_ok,
+                        (dialog, which) -> {
+                            getActivity()
+                                    .getSharedPreferences("doze_settings", Activity.MODE_PRIVATE)
+                                    .edit()
+                                    .putBoolean("first_help_shown", true)
+                                    .commit();
+                            dialog.cancel();
+                        })
+                .create();
+        helpDialog.show();
         }
     }
 }


### PR DESCRIPTION
As preparation to upgrade the sdk get rid of this private class. Fragments must be a public static class to be properly recreated from instance state.

Also change the behaviour to only hide the dialog when confirmed instead of also when it is cancelled.

Change-Id: I171aa2345058edae7520c37942c3c11b3cdfdfdc | AOSP

From: https://review.lineageos.org/c/LineageOS/android_device_lenovo_sm8150-common/+/388517/5