### PR TITLE
lavender: doze: Remove minSdkVersion/targetSdkVersion

### DIFF
--- a/doze/AndroidManifest.xml
+++ b/doze/AndroidManifest.xml
@@ -26,10 +26,6 @@
 
     <protected-broadcast android:name="com.android.systemui.doze.pulse" />
 
-    <uses-sdk
-        android:minSdkVersion="24"
-        android:targetSdkVersion="24" />
-
     <application
         android:label="@string/device_settings_app_name"
         android:persistent="true">


### PR DESCRIPTION
This is a privileged app using platform APIs, SDK version has no effect

Change-Id: I4e572ae0012bf0a1efa0b639a46f442caa7ca9ea | AOSP

From: https://review.lineageos.org/c/LineageOS/android_device_lenovo_sm8150-common/+/388232/6