### PR TITLE
lavender: doze: Add an exported flag in manifest

### DIFF
--- a/doze/AndroidManifest.xml
+++ b/doze/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
      Copyright (C) 2015-2016 The CyanogenMod Project
-                   2017 The LineageOS Project
+                   2017-2024 The LineageOS Project
 
      Licensed under the Apache License, Version 2.0 (the "License");
      you may not use this file except in compliance with the License.
@@ -34,7 +34,8 @@
         android:label="@string/device_settings_app_name"
         android:persistent="true">
 
-        <receiver android:name=".BootCompletedReceiver">
+        <receiver android:name=".BootCompletedReceiver"
+                  android:exported="false">
             <intent-filter>
                 <action android:name="android.intent.action.BOOT_COMPLETED" />
                 <category android:name="android.intent.category.DEFAULT" />
@@ -43,11 +44,13 @@
 
         <service
             android:name=".DozeService"
+            android:exported="true"
             android:permission="XiaomiDozeService">
         </service>
 
         <activity
             android:name=".DozeSettingsActivity"
+            android:exported="true"
             android:label="@string/ambient_display_title"
             android:theme="@style/Theme.SubSettingsBase">
             <intent-filter>


### PR DESCRIPTION
Targeting S+ (version 31 and above) requires that an explicit value for android:exported be defined when intent filters are present

Change-Id: I12d27c23624eb5259da582b86ac1bd7572754f0c | AOSP

From: https://review.lineageos.org/c/LineageOS/android_device_lenovo_sm8150-common/+/388284/7