### PR TITLE
lavender: Update makefile to use the AIDL Wifi Vendor HAL.

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -450,7 +450,7 @@ PRODUCT_COPY_FILES += \
 
 # Wifi
 PRODUCT_PACKAGES += \
-    android.hardware.wifi@1.0-service \
+    android.hardware.wifi-service \
     hostapd \
     libwifi-hal-qcom \
     libwpa_client \


### PR DESCRIPTION
Bug: 274964641 | AOSP
Test: Pre-submit tests
Change-Id: I4d9114377fe75b593bbfe6a59f03d8f5d607d6a1 | AOSP

From: https://review.lineageos.org/c/LineageOS/android_device_xiaomi_sm6150-common/+/372753