### PR TITLE
lavender: gps: Don't include cutils/threads.h [1/2]

### DIFF
--- a/gps/pla/oe/loc_pla.h
+++ b/gps/pla/oe/loc_pla.h
@@ -52,7 +52,6 @@ extern "C" {
 
 #ifndef FEATURE_EXTERNAL_AP
 #include <cutils/properties.h>
-#include <cutils/threads.h>
 #include <cutils/sched_policy.h>
 #endif /* FEATURE_EXTERNAL_AP */
 #include <pthread.h>


### PR DESCRIPTION
Bug: 289414897 | AOSP
Test: buildserver
Change-Id: I14b99f42feaae7af00cbd17cfe482eb2e5da71e8 | AOSP

From: https://review.lineageos.org/c/LineageOS/android_device_xiaomi_sm6150-common/+/386685/4