### PR TITLE
lavender: gps: Don't include cutils/threads.h [2/2]

### DIFF
--- a/gps/pla/android/loc_pla.h
+++ b/gps/pla/android/loc_pla.h
@@ -39,7 +39,6 @@ extern "C" {
 #endif
 
 #include <cutils/properties.h>
-#include <cutils/threads.h>
 #include <cutils/sched_policy.h>
 #include <cutils/android_filesystem_config.h>
 #include <string.h>


### PR DESCRIPTION
Bug: 289414897 | AOSP
Test: buildserver
Change-Id: I14b99f42feaae7af00cbd17cfe482eb2e5da71e8 | AOSP

From: https://review.lineageos.org/c/LineageOS/android_device_xiaomi_sm6150-common/+/386685/4