### PR TITLE
lavender: gps: Add NULL check before object access

### DIFF
--- a/gps/android/utils/battery_listener.cpp
+++ b/gps/android/utils/battery_listener.cpp
@@ -177,16 +177,19 @@ BatteryListenerImpl::~BatteryListenerImpl()
 {
     {
         std::lock_guard<std::mutex> _l(mLock);
-        if (mHealth != NULL)
+        if (mHealth != NULL)  {
             mHealth->unlinkToDeath(this);
             auto r = mHealth->unlinkToDeath(this);
             if (!r.isOk() || r == false) {
                 ALOGE("Transaction error in unregister to HealthHAL death: %s",
                         r.description().c_str());
             }
+        }
     }
     mDone = true;
-    mThread->join();
+    if (NULL !=  mThread) {
+        mThread->join();
+    }
 }
 
 void BatteryListenerImpl::serviceDied(uint64_t cookie __unused,
@@ -201,7 +204,9 @@ void BatteryListenerImpl::serviceDied(uint64_t cookie __unused,
         ALOGI("health service died, reinit");
         mDone = true;
     }
-    mThread->join();
+    if (NULL !=  mThread) {
+        mThread->join();
+    }
     std::lock_guard<std::mutex> _l(mLock);
     init();
 }


### PR DESCRIPTION
Correct the NULL check code block and add NULL check before object access.

Change-Id: Ic41b781b41fb4e21bbff8801d500a41a6d7219d0 | AOSP
CRs-fixed: 3084543 | AOSP

From : https://review.lineageos.org/c/LineageOS/android_device_xiaomi_sm6150-common/+/372752/15