### PR TITLE
lavender: gps: Fix unqualified-std-cast-call warning

### DIFF
--- a/gps/utils/LocIpc.cpp
+++ b/gps/utils/LocIpc.cpp
@@ -300,7 +300,7 @@ public:
     inline LocIpcRunnable(LocIpc& locIpc, unique_ptr<LocIpcRecver>& ipcRecver) :
             mAbortCalled(false),
             mLocIpc(locIpc),
-            mIpcRecver(move(ipcRecver)) {}
+            mIpcRecver(std::move(ipcRecver)) {}
     inline bool run() override {
         if (mIpcRecver != nullptr) {
             mLocIpc.startBlockingListening(*(mIpcRecver.get()));


### PR DESCRIPTION
hardware/qcom/sm8150/gps/utils/LocIpc.cpp:315:24: error: unqualified call to std::move [-Werror,-Wunqualified-std-cast-call]
            mIpcRecver(move(ipcRecver)) {}
                       ^
                       std::

Test: presubmit
Change-Id: I7378416e788f20ebb3f8d1d065d60964dc76eb99 | AOSP

From: https://review.lineageos.org/c/LineageOS/android_device_xiaomi_sm6150-common/+/373683/11